### PR TITLE
rxpress V0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+/src/main.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "rxpress"
-version = "0.1.0"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rxpress"
 license = "MIT"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "rxpress is an open-source server library in Rust similar to express in NodeJS. Built from the ground up with a focus on learning and building modern HTTP servers."
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,121 @@
+//! # rxpress
+//!
+//! `rxpress` is a minimal HTTP server framework inspired by Express.js, written in Rust.
+//!
+//! ## Quick Start
+//!
+//! ```no_run
+//! use rxpress::Server;
+//!
+//! fn main() {
+//!     let mut app = Server::new("8080");
+//!
+//!     // A simple GET route
+//!     app.get("/", |_req, res| {
+//!         res.send("Hello from rxpress!");
+//!     });
+//!
+//!     // A POST route
+//!     app.post("/submit", |_req, res| {
+//!         res.status(201).json(r#"{"status":"created"}"#);
+//!     });
+//!
+//!     app.run(); // blocks forever
+//! }
+//! ```
+//!
+//! ## Route Parameters
+//!
+//! ```no_run
+//! use rxpress::Server;
+//!
+//! fn main() {
+//!     let mut app = Server::new("3000");
+//!
+//!     app.get("/users/:id", |req, res| {
+//!         if let Some(id) = req.param("id") {
+//!             res.send(&format!("User ID: {}", id));
+//!         } else {
+//!             res.status(400).send("Missing ID");
+//!         }
+//!     });
+//!
+//!     app.run();
+//! }
+//! ```
+//!
+//! ## Query Parameters
+//!
+//! ```no_run
+//! use rxpress::Server;
+//!
+//! fn main() {
+//!     let mut app = Server::new("3000");
+//!
+//!     app.get("/search", |req, res| {
+//!         if let Some(query) = req.query("q") {
+//!             res.send(&format!("Searching for: {}", query));
+//!         } else {
+//!             res.status(400).send("Missing query parameter `q`");
+//!         }
+//!     });
+//!
+//!     app.run();
+//! }
+//! ```
+//!
+//! ## Custom Headers
+//!
+//! ```no_run
+//! use rxpress::Server;
+//!
+//! fn main() {
+//!     let mut app = Server::new("3000");
+//!
+//!     app.get("/headers", |_req, res| {
+//!         res.set_header("X-Custom-Header", "rxpress")
+//!            .send("Custom header sent!");
+//!     });
+//!
+//!     app.run();
+//! }
+//! ```
+//!
+//! ## Multiple Methods
+//!
+//! ```no_run
+//! use rxpress::Server;
+//!
+//! fn main() {
+//!     let mut app = Server::new("3000");
+//!
+//!     app.put("/update", |_req, res| {
+//!         res.send("Resource updated!");
+//!     });
+//!
+//!     app.delete("/delete", |_req, res| {
+//!         res.send("Resource deleted!");
+//!     });
+//!
+//!     app.patch("/patch", |_req, res| {
+//!         res.send("Resource patched!");
+//!     });
+//!
+//!     app.options("/any", |_req, res| {
+//!         res.set_header("Allow", "GET, POST, OPTIONS");
+//!         res.send("Allowed methods: GET, POST, OPTIONS");
+//!     });
+//!
+//!     app.run();
+//! }
+//! ```
+
+pub mod request;
+pub mod response;
+pub mod route;
+pub mod router;
 pub mod server;
+
+pub use request::Request;
+pub use response::Response;
 pub use server::Server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,0 @@
-use rxpress::Server;
-
-fn main() {
-    let app = Server::new("8080");
-    app.run();
-}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,161 @@
+use std::collections::HashMap;
+
+/// Represents an HTTP request.
+///
+/// Stores method, path, headers, query parameters, route parameters, and body.
+pub struct Request {
+    pub method: String,
+    pub path: String,
+    pub headers: HashMap<String, String>,
+    pub version: String,
+    pub query: HashMap<String, String>,
+    pub params: HashMap<String, String>,
+    pub body: String,
+}
+
+impl Request {
+    /// Creates a new [`Request`] from raw parts.
+    ///
+    /// # Arguments
+    /// * `request_line` - The first line of the HTTP request (`"GET /foo?bar=1 HTTP/1.1"`).
+    /// * `headers` - The parsed HTTP headers.
+    /// * `body` - The request body as a string.
+    ///
+    /// # Example
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rxpress::Request;
+    ///
+    /// let headers = HashMap::new();
+    /// let req = Request::new("GET /hello?developer=alfaarghy HTTP/1.1", headers, "".to_string());
+    /// assert_eq!(req.method, "GET");
+    /// assert_eq!(req.path, "/hello");
+    /// assert_eq!(req.query("developer"), Some(&"alfaarghy".to_string()));
+    /// ```
+    pub fn new(request_line: &str, headers: HashMap<String, String>, body: String) -> Request {
+        let parts: Vec<&str> = request_line.split_whitespace().collect();
+
+        let (method, full_path, version) = match parts.as_slice() {
+            [m, p, v] => (m.to_string(), p.to_string(), v.to_string()),
+            _ => ("GET".to_string(), "/".to_string(), "HTTP/1.1".to_string()),
+        };
+
+        let (path, query) = if let Some((p, q)) = full_path.split_once('?') {
+            (p.to_string(), Self::parse_query(q))
+        } else {
+            (full_path, HashMap::new())
+        };
+
+        Request {
+            method,
+            path,
+            headers,
+            version,
+            query,
+            params: HashMap::new(),
+            body,
+        }
+    }
+
+    /// Gets a header value by key (case-insensitive).
+    ///
+    /// # Example
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rxpress::Request;
+    ///
+    /// let mut headers = HashMap::new();
+    /// headers.insert("Content-Type".into(), "application/json".into());
+    /// let req = Request::new("GET / HTTP/1.1", headers, "".into());
+    ///
+    /// assert_eq!(req.header("content-type"), Some(&"application/json".to_string()));
+    /// ```
+    pub fn header(&self, key: &str) -> Option<&String> {
+        self.headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+            .map(|(_, v)| v)
+    }
+
+    /// Gets a route parameter value (set by the router).
+    ///
+    /// # Example
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rxpress::Request;
+    ///
+    /// let mut req = Request::new("GET /users/42 HTTP/1.1", HashMap::new(), "".into());
+    /// req.params.insert("id".into(), "42".into());
+    ///
+    /// assert_eq!(req.param("id"), Some(&"42".to_string()));
+    /// ```
+    pub fn param(&self, key: &str) -> Option<&String> {
+        self.params.get(key)
+    }
+
+    /// Gets a query parameter value.
+    ///
+    /// # Example
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rxpress::Request;
+    ///
+    /// let headers = HashMap::new();
+    /// let req = Request::new("GET /search?q=rust HTTP/1.1", headers, "".into());
+    ///
+    /// assert_eq!(req.query("q"), Some(&"rust".to_string()));
+    /// ```
+    pub fn query(&self, key: &str) -> Option<&String> {
+        self.query.get(key)
+    }
+
+    /*---- Private Functions ----*/
+    /// Parses query parameters into a [`HashMap`].
+    fn parse_query(q: &str) -> HashMap<String, String> {
+        let mut map: HashMap<String, String> = HashMap::new();
+
+        for pair in q.split('&') {
+            if let Some((k, v)) = pair.split_once('=') {
+                map.insert(k.to_string(), v.to_string());
+            } else {
+                map.insert(pair.to_string(), "".to_string());
+            }
+        }
+
+        map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_request_line_and_query() {
+        let mut headers = HashMap::new();
+        headers.insert("Host".into(), "localhost".into());
+
+        let req = Request::new(
+            "GET /hello?developer=alfaarghya HTTP/1.1",
+            headers,
+            "".into(),
+        );
+
+        assert_eq!(req.method, "GET");
+        assert_eq!(req.path, "/hello");
+        assert_eq!(req.version, "HTTP/1.1");
+        assert_eq!(req.query("developer"), Some(&"alfaarghya".to_string()));
+    }
+
+    #[test]
+    fn test_headers_case_insensitive() {
+        let mut headers = HashMap::new();
+        headers.insert("Content-Type".into(), "application/json".into());
+
+        let req = Request::new("GET / HTTP/1.1", headers, "".into());
+        assert_eq!(
+            req.header("content-type"),
+            Some(&"application/json".to_string())
+        );
+    }
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,105 @@
+use std::collections::HashMap;
+use std::io::Write;
+use std::net::TcpStream;
+
+/// Represents an HTTP response.
+///
+/// Used by route handlers to set status codes, headers, and send body content.
+pub struct Response<'a> {
+    pub stream: &'a mut TcpStream,
+    pub headers: HashMap<String, String>,
+    pub status: u16,
+}
+
+impl<'a> Response<'a> {
+    /// Creates a new [`Response`] object with default status `200 OK`.
+    pub fn new(stream: &'a mut TcpStream) -> Response<'a> {
+        let mut headers = HashMap::new();
+        headers.insert("HTTP-Server-Powered-By".to_string(), "rxpress".to_string());
+
+        Response {
+            stream,
+            headers,
+            status: 200,
+        }
+    }
+
+    /// Sets the HTTP status code.
+    ///
+    /// # Example
+    /// ```
+    /// # use rxpress::{Request, Response};
+    /// # fn handler(_req: &Request, res: &mut Response) {
+    /// res.status(404).send("Not found");
+    /// # }
+    /// ```
+    pub fn status(&mut self, code: u16) -> &mut Self {
+        self.status = code;
+        self
+    }
+
+    /// Sets a header on the response.
+    ///
+    /// # Example
+    /// ```
+    /// # use rxpress::{Request, Response};
+    /// # fn handler(_req: &Request, res: &mut Response) {
+    /// res.set_header("X-Custom", "1234");
+    /// res.send("ok");
+    /// # }
+    /// ```
+    pub fn set_header(&mut self, key: &str, value: &str) -> &mut Self {
+        self.headers.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    /// Sends a plain text response with `Content-Type: text/plain`.
+    ///
+    /// # Example
+    /// ```
+    /// # use rxpress::{Request, Response};
+    /// # fn handler(_req: &Request, res: &mut Response) {
+    /// res.send("Hello, plain text!");
+    /// # }
+    /// ```
+    pub fn send(&mut self, msg: &str) {
+        self.set_header("Content-Type", "text/plain");
+        self.write_response(msg.as_bytes());
+    }
+
+    /// Sends a JSON response with `Content-Type: application/json`.
+    ///
+    /// # Example
+    /// ```
+    /// # use rxpress::{Request, Response};
+    /// # fn handler(_req: &Request, res: &mut Response) {
+    /// res.json(r#"{"message":"ok"}"#);
+    /// # }
+    /// ```
+    pub fn json(&mut self, msg: &str) {
+        self.set_header("Content-Type", "application/json");
+        self.write_response(msg.as_bytes());
+    }
+
+    /*---- Private Functions ----*/
+    fn write_response(&mut self, msg: &[u8]) {
+        let headers = self
+            .headers
+            .iter()
+            .map(|(k, v)| format!("{}: {}", k, v))
+            .collect::<Vec<String>>()
+            .join("\r\n");
+
+        // println!("[write_response]: {headers:?}");
+        let res = format!(
+            "HTTP/1.1 {} OK\r\n{}\r\nContent-Length: {}\r\n\r\n",
+            self.status,
+            headers,
+            msg.len()
+        );
+
+        self.stream.write_all(res.as_bytes()).unwrap();
+        self.stream.write_all(msg).unwrap();
+        self.stream.flush().unwrap();
+    }
+}

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,0 +1,85 @@
+use crate::request::Request;
+use crate::server::Handler;
+
+/// Represents a single route definition (method + path + handler).
+pub struct Route {
+    pub method: String,
+    pub path: String,
+    pub handler: Handler,
+}
+
+impl Route {
+    /// Creates a new [`Route`].
+    pub fn new(method: &str, path: &str, handler: Handler) -> Route {
+        Route {
+            method: method.to_string(),
+            path: path.to_string(),
+            handler,
+        }
+    }
+
+    /// Checks if this route matches a given request.
+    ///
+    /// Supports path parameters like `/users/:id`.
+    pub fn matches(&self, req: &mut Request) -> bool {
+        if self.method != req.method.to_uppercase() {
+            return false;
+        }
+
+        let route_parts: Vec<&str> = self.path.split('/').collect();
+        let req_parts: Vec<&str> = req.path.split('/').collect();
+
+        if route_parts.len() != req_parts.len() {
+            return false;
+        }
+
+        for (r, p) in route_parts.iter().zip(req_parts.iter()) {
+            if r.starts_with(':') {
+                // store param
+                let key = r.trim_start_matches(':').to_string();
+                if !p.is_empty() {
+                    req.params.insert(key, p.to_string());
+                }
+                println!("[params]: {:?}", req.params);
+            } else if r != p {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn dummy_handler(_req: &Request, _res: &mut crate::Response) {}
+
+    #[test]
+    fn test_route_match_static() {
+        let route = Route::new("GET", "/hello", dummy_handler);
+        let req = Request::new("GET /hello HTTP/1.1", HashMap::new(), "".into());
+        let mut req = req;
+        assert!(route.matches(&mut req));
+    }
+
+    #[test]
+    fn test_route_match_with_param() {
+        let route = Route::new("GET", "/users/:id", dummy_handler);
+        let req = Request::new("GET /users/123 HTTP/1.1", HashMap::new(), "".into());
+        let mut req = req;
+        assert!(route.matches(&mut req));
+        assert_eq!(req.param("id"), Some(&"123".to_string()));
+    }
+
+    #[test]
+    fn test_route_with_missing_param() {
+        let route = Route::new("GET", "/users/:id", dummy_handler);
+        let req = Request::new("GET /users/ HTTP/1.1", HashMap::new(), "".into());
+        let mut req = req;
+        assert!(route.matches(&mut req));
+        assert_eq!(req.param("id"), None);
+    }
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,0 +1,33 @@
+use crate::request::Request;
+use crate::response::Response;
+use crate::route::Route;
+use crate::server::Handler;
+
+/// Router manages all registered routes and dispatches requests.
+pub struct Router {
+    routes: Vec<Route>,
+}
+
+impl Router {
+    /// Creates a new, empty [`Router`].
+    pub fn new() -> Router {
+        Router { routes: Vec::new() }
+    }
+
+    /// Adds a new route with method, path, and handler.
+    pub fn add_route(&mut self, method: &str, path: &str, handler: Handler) {
+        self.routes.push(Route::new(method, path, handler));
+    }
+
+    /// Dispatches a request to the first matching route handler.
+    pub fn handle(&self, req: &mut Request, res: &mut Response) {
+        for route in &self.routes {
+            if route.matches(req) {
+                (route.handler)(req, res);
+                return;
+            }
+        }
+
+        res.status(404).send("404 Not Found");
+    }
+}


### PR DESCRIPTION
## Handle _Request_ & _Response_ for different `/routes` 

### 🔹 New Modules & Features  
- **`request.rs`**  
  - Implemented `Request` struct to represent HTTP requests.  
  - Added support for parsing:  
    - Method, path, and HTTP version.  
    - Headers (case-insensitive lookup).  
    - Query parameters (`?key=value`).  
    - Route params (to be set during routing).  
  - Provided helper methods: `header()`, `param()`, `query()`.  

- **`response.rs`**  
  - Implemented `Response` struct to handle HTTP responses.  
  - Default `200 OK` status with `rxpress` server header.  
  - Added builder-style methods:  
    - `status()` → set status code.  
    - `set_header()` → add/overwrite headers.  
    - `send()` → send plain text responses.  
    - `json()` → send JSON responses.  

