### PR TITLE
rxpress V0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "rxpress"
-version = "0.2.0"
+version = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rxpress"
 license = "MIT"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Arghya Das <arghya.coding@gmail.com>"]
 description = "rxpress is an open-source server library in Rust similar to express in NodeJS. Built from the ground up with a focus on learning and building modern HTTP servers."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "rxpress is an open-source server library in Rust similar to expre
 documentation = "https://docs.rs/rxpress"
 repository = "https://github.com/alfaarghya/rxpress"
 keywords = ["rxpress", "http", "server", "http-server", "backend"]
-categories = ["http-server", "server", "web-programming"]
+categories = ["web-programming", "web-programming::http-server"]
 
 [lib]
 name = "rxpress"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "rxpress is an open-source server library in Rust similar to expre
 # homepage = "https://crates.io/crates/rxpress"
 documentation = "https://docs.rs/rxpress"
 repository = "https://github.com/alfaarghya/rxpress"
-keywords = ["rxpress", "http", "server", "http-server", "backend", "web"]
+keywords = ["rxpress", "http", "server", "http-server", "backend"]
 categories = ["http-server", "server", "web-programming"]
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,12 @@
 //!
 //! `rxpress` is a minimal HTTP server framework inspired by Express.js, written in Rust.
 //!
+//! ## Features
+//! - Define routes for all major HTTP methods (GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD)
+//! - Route parameters and query parameters support
+//! - Custom response headers and status codes
+//! - Minimalistic, synchronous design
+//!
 //! ## Quick Start
 //!
 //! ```no_run
@@ -23,6 +29,13 @@
 //!     app.run(); // blocks forever
 //! }
 //! ```
+//! ## Module Overview
+//! - [`request`] - Defines the [`Request`] struct for accessing request data.
+//! - [`response`] - Defines the [`Response`] struct for sending responses.
+//! - [`route`] - Defines a single route with path, method, and handler.
+//! - [`router`] - Handles route registration and request dispatching.
+//! - [`server`] - The main [`Server`] struct to run the HTTP server.
+//! - [`status`] - Standard HTTP status codes as [`HttpStatus`] enum.
 //!
 //! ## Route Parameters
 //!
@@ -75,6 +88,97 @@
 //!     app.get("/headers", |_req, res| {
 //!         res.set_header("X-Custom-Header", "rxpress")
 //!            .send("Custom header sent!");
+//!     });
+//!
+//!     app.run();
+//! }
+//! ```
+//! ## Custom Status Examples
+//!
+//! Demonstrates using `status()` with enum, numeric codes, and custom reason.
+//! Only the first response (`send()` or `json()`) will be sent; subsequent calls
+//! will print a warning and be ignored.
+//!
+//! ### Example 1: Standard Enum
+//! ```no_run
+//! # use rxpress::{Server, HttpStatus};
+//! # fn main() {
+//! let mut app = Server::new("3000");
+//!
+//! app.get("/error_enum", |_req, res| {
+//!     res.status(HttpStatus::Forbidden).send("Forbidden!");
+//!     res.send("Ignored response"); // Will print warning
+//! });
+//!
+//! app.run();
+//! # }
+//! ```
+//!
+//! ### Example 2: Custom Code
+//! ```no_run
+//! # use rxpress::Server;
+//! # fn main() {
+//! let mut app = Server::new("3000");
+//!
+//! app.get("/error_code", |_req, res| {
+//!     res.status(511).json(r#"{"error":"Network Auth Required"}"#);
+//!     res.json(r#"{"ignored": true}"#); // Will print warning
+//! });
+//!
+//! app.run();
+//! # }
+//! ```
+//!
+//! ### Example 3: Custom Code + Reason
+//! ```no_run
+//! # use rxpress::Server;
+//! # fn main() {
+//! let mut app = Server::new("3000");
+//!
+//! app.get("/error_custom", |_req, res| {
+//!     res.status((599, "Network Timeout")).send("Timeout!");
+//!     res.send("Ignored"); // Will print warning
+//! });
+//!
+//! app.run();
+//! # }
+//! ```
+//!
+//! ## HTML Responses
+//!
+//! You can use `html()` to send inline HTML with the proper `Content-Type`.
+//!
+//! ```no_run
+//! use rxpress::Server;
+//!
+//! fn main() {
+//!     let mut app = Server::new("3000");
+//!
+//!     app.get("/page", |_req, res| {
+//!         res.html("<h1>Hello from rxpress!</h1><p>This is HTML.</p>");
+//!     });
+//!
+//!     app.run();
+//! }
+//! ```
+//!
+//! ## Serving HTML Files
+//!
+//! Use `html_file()` to serve HTML from disk. If the file is missing or unreadable,
+//! a `500 Internal Server Error` is automatically returned.
+//!
+//! ```no_run
+//! use rxpress::Server;
+//!
+//! fn main() {
+//!     let mut app = Server::new("3000");
+//!
+//!     app.get("/home", |_req, res| {
+//!         res.html_file("index.html");
+//!     });
+//!
+//!     app.get("/about", |_req, res| {
+//!         res.html_file("about.html");
 //!     });
 //!
 //!     app.run();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,9 @@ pub mod response;
 pub mod route;
 pub mod router;
 pub mod server;
+pub mod status;
 
 pub use request::Request;
 pub use response::Response;
 pub use server::Server;
+pub use status::HttpStatus;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,15 +1,101 @@
+//! # Request Module
+//!
+//! The [`Request`] struct represents an incoming HTTP request.  
+//! It stores the request line, headers, body, query parameters, and path parameters.
+//!
+//! ## Example
+//! ```no_run
+//! use rxpress::Server;
+//!
+//! fn main() {
+//!     let mut app = Server::new("3000");
+//!
+//!     // header() and header_or()
+//!     app.get("/headers", |req, res| {
+//!         // header() returns Option<&String>
+//!         if let Some(ua) = req.header("user-agent") {
+//!             res.send(&format!("Your User-Agent: {}", ua));
+//!         } else {
+//!             res.send("User-Agent header not found");
+//!         }
+//!         // header_or() returns default if header missing
+//!         let host = req.header_or("host", "localhost");
+//!         println!("Host: {}", host);
+//!     });
+//!
+//!     // header_expect()
+//!     app.get("/auth", |req, res| {
+//!         match req.header_expect("Authorization") {
+//!             Ok(token) => res.send(&format!("Token: {}", token)),
+//!             Err(err) => res.status(400).send(&err),
+//!         }
+//!     });
+//!
+//!     // param() and param_or()
+//!     app.get("/users/:id", |req, res| {
+//!         // param() returns Option<&String>
+//!         if let Some(id) = req.param("id") {
+//!             res.send(&format!("User ID: {}", id));
+//!         } else {
+//!             res.send("Missing user ID");
+//!         }
+//!         // param_or() returns default if param missing
+//!         let user_id = req.param_or("id", "0");
+//!         println!("User ID (or default): {}", user_id);
+//!     });
+//!
+//!     // param_expect()
+//!     app.get("/secure/:id", |req, res| {
+//!         match req.param_expect("id") {
+//!             Ok(id) => res.send(&format!("Secure User ID: {}", id)),
+//!             Err(err) => res.status(400).send(&err),
+//!         }
+//!     });
+//!
+//!     // query() and query_or()
+//!     app.get("/search", |req, res| {
+//!         // query() returns Option<&String>
+//!         if let Some(q) = req.query("q") {
+//!             res.send(&format!("Searching for: {}", q));
+//!         } else {
+//!             res.send("Missing query param `q`");
+//!         }
+//!         // query_or() returns default if query missing
+//!         let query = req.query_or("q", "none");
+//!         println!("Query (or default): {}", query);
+//!     });
+//!
+//!     // query_expect()
+//!     app.get("/secure_search", |req, res| {
+//!         match req.query_expect("q") {
+//!             Ok(q) => res.send(&format!("Secure search for: {}", q)),
+//!             Err(err) => res.status(400).send(&err),
+//!         }
+//!     });
+//!
+//!     app.run();
+//! }
+//! ```
+
 use std::collections::HashMap;
 
 /// Represents an HTTP request.
 ///
 /// Stores method, path, headers, query parameters, route parameters, and body.
 pub struct Request {
+    /// HTTP method (e.g., `GET`, `POST`)
     pub method: String,
+    /// Path portion of the request (e.g., `/users/123`)
     pub path: String,
+    /// Request headers
     pub headers: HashMap<String, String>,
+    /// HTTP version (e.g., `HTTP/1.1`)
     pub version: String,
+    /// Query parameters parsed into key-value pairs
     pub query: HashMap<String, String>,
+    /// Path parameters extracted from route definitions
     pub params: HashMap<String, String>,
+    /// Request body as a string
     pub body: String,
 }
 
@@ -60,6 +146,22 @@ impl Request {
     /// Gets a header value by key (case-insensitive).
     ///
     /// # Example
+    ///
+    /// ```no_run
+    /// use rxpress::Server;
+    ///
+    /// let mut app = Server::new("8080");
+    ///
+    /// app.get("/test", |req, res| {
+    ///     if let Some(token) = req.header("Authorization") {
+    ///         res.send(&format!("Token: {}", token));
+    ///     } else {
+    ///         res.status(400).send("Missing Authorization header");
+    ///     }
+    /// });
+    /// ```
+    /// ---
+    /// ## Test
     /// ```
     /// use std::collections::HashMap;
     /// use rxpress::Request;
@@ -69,6 +171,7 @@ impl Request {
     /// let req = Request::new("GET / HTTP/1.1", headers, "".into());
     ///
     /// assert_eq!(req.header("content-type"), Some(&"application/json".to_string()));
+    /// assert_eq!(req.header("non-existent"), None);
     /// ```
     pub fn header(&self, key: &str) -> Option<&String> {
         self.headers
@@ -77,9 +180,91 @@ impl Request {
             .map(|(_, v)| v)
     }
 
+    /// Gets a header value or returns a default if not present.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rxpress::Server;
+    ///
+    /// let mut app = Server::new("8080");
+    ///
+    /// app.get("/test", |req, res| {
+    ///     let content_type = req.header_or("Content-Type", "text/plain");
+    ///     res.send(&format!("Content-Type: {}", content_type));
+    /// });
+    /// ```
+    /// ---
+    /// ## Test
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rxpress::Request;
+    ///
+    /// let req = Request::new("GET / HTTP/1.1", HashMap::new(), "".into());
+    /// assert_eq!(req.header_or("Content-Type", "text/plain"), "text/plain");
+    /// ```
+    pub fn header_or<'a>(&'a self, key: &str, default: &'a str) -> &'a str {
+        self.headers
+            .get(key)
+            .map(|val| val.as_str())
+            .unwrap_or(default)
+    }
+
+    /// Gets a header value or returns an error message if missing.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use rxpress::Server;
+    ///
+    /// let mut app = Server::new("8080");
+    ///
+    /// app.get("/test", |req, res| {
+    ///     match req.header_expect("Authorization") {
+    ///         Ok(token) => res.send(token),
+    ///         Err(err) => res.status(400).send(&err),
+    ///     }
+    /// });
+    /// ```
+    /// ---
+    /// ## Test
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rxpress::Request;
+    ///
+    /// let mut headers = HashMap::new();
+    /// headers.insert("Authorization".into(), "Bearer abc123".into());
+    /// let req = Request::new("GET / HTTP/1.1", headers, "".into());
+    ///
+    /// assert_eq!(req.header_expect("Authorization").unwrap(), "Bearer abc123");
+    /// assert!(req.header_expect("X-Token").is_err());
+    /// ```
+    pub fn header_expect(&self, key: &str) -> Result<&str, String> {
+        self.headers.get(key).map(|val| val.as_str()).ok_or(format!(
+            "[rxpress error]: Required header `{}` is missing. \
+            Please include it in your request, e.g., `{}: value`.",
+            key, key
+        ))
+    }
+
     /// Gets a route parameter value (set by the router).
     ///
     /// # Example
+    /// ```no_run
+    /// use rxpress::Server;
+    ///
+    /// let mut app = Server::new("8080");
+    ///
+    /// app.get("/users/:id", |req, res| {
+    ///     if let Some(id) = req.param("id") {
+    ///         res.send(&format!("User ID: {}", id));
+    ///     } else {
+    ///         res.status(400).send("Missing user ID");
+    ///     }
+    /// });
+    /// ```
+    /// ---
+    /// ## Test
     /// ```
     /// use std::collections::HashMap;
     /// use rxpress::Request;
@@ -93,20 +278,159 @@ impl Request {
         self.params.get(key)
     }
 
+    /// Gets a route parameter or returns a default if missing.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use rxpress::Server;
+    ///
+    /// let mut app = Server::new("8080");
+    ///
+    /// app.get("/users/:id", |req, res| {
+    ///     let id = req.param_or("id", "0");
+    ///     res.send(&format!("User ID: {}", id));
+    /// });
+    /// ```
+    /// ---
+    /// ## Test
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rxpress::Request;
+    ///
+    /// let req = Request::new("GET /users/ HTTP/1.1", HashMap::new(), "".into());
+    /// assert_eq!(req.param_or("id", "0"), "0");
+    /// ```
+    pub fn param_or<'a>(&'a self, key: &str, default: &'a str) -> &'a str {
+        self.params
+            .get(key)
+            .map(|val| val.as_str())
+            .unwrap_or(default)
+    }
+
+    /// Gets a route parameter or returns an error message if missing.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use rxpress::Server;
+    ///
+    /// let mut app = Server::new("8080");
+    ///
+    /// app.get("/users/:id", |req, res| {
+    ///     match req.param_expect("id") {
+    ///         Ok(id) => res.send(&format!("User ID: {}", id)),
+    ///         Err(err) => res.status(400).send(&err),
+    ///     }
+    /// });
+    /// ```
+    /// ---
+    /// ## Test
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rxpress::Request;
+    ///
+    /// let mut req = Request::new("GET /users/42 HTTP/1.1", HashMap::new(), "".into());
+    /// req.params.insert("id".into(), "42".into());
+    /// assert_eq!(req.param_expect("id").unwrap(), "42");
+    /// assert!(req.param_expect("username").is_err());
+    /// ```
+    pub fn param_expect(&self, key: &str) -> Result<&str, String> {
+        self.params.get(key).map(|val| val.as_str()).ok_or(format!(
+            "[rxpress error]: Required route parameter `{}` is missing. \
+            Ensure your route includes it, e.g., `/route/:{}`.",
+            key, key
+        ))
+    }
+
     /// Gets a query parameter value.
     ///
     /// # Example
+    /// ```no_run
+    /// use rxpress::Server;
+    ///
+    /// let mut app = Server::new("8080");
+    ///
+    /// app.get("/search", |req, res| {
+    ///     if let Some(q) = req.query("q") {
+    ///         res.send(&format!("Searching for: {}", q));
+    ///     } else {
+    ///         res.status(400).send("Missing query parameter `q`");
+    ///     }
+    /// });
+    /// ```
+    /// ---
+    /// ## Test
     /// ```
     /// use std::collections::HashMap;
     /// use rxpress::Request;
     ///
     /// let headers = HashMap::new();
     /// let req = Request::new("GET /search?q=rust HTTP/1.1", headers, "".into());
-    ///
     /// assert_eq!(req.query("q"), Some(&"rust".to_string()));
     /// ```
     pub fn query(&self, key: &str) -> Option<&String> {
         self.query.get(key)
+    }
+
+    /// Gets a query parameter or returns a default if missing.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use rxpress::Server;
+    ///
+    /// let mut app = Server::new("8080");
+    ///
+    /// app.get("/search", |req, res| {
+    ///     let q = req.query_or("q", "none");
+    ///     res.send(&format!("Query: {}", q));
+    /// });
+    /// ```
+    /// ---
+    /// ## Test
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rxpress::Request;
+    ///
+    /// let req = Request::new("GET /search HTTP/1.1", HashMap::new(), "".into());
+    /// assert_eq!(req.query_or("q", "none"), "none");
+    /// ````
+    pub fn query_or<'a>(&'a self, key: &str, default: &'a str) -> &'a str {
+        self.query
+            .get(key)
+            .map(|val| val.as_str())
+            .unwrap_or(default)
+    }
+
+    /// Gets a query parameter or returns an error message if missing.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use rxpress::Server;
+    ///
+    /// let mut app = Server::new("8080");
+    ///
+    /// app.get("/search", |req, res| {
+    ///     match req.query_expect("q") {
+    ///         Ok(val) => res.send(val),
+    ///         Err(err) => res.status(400).send(&err),
+    ///     }
+    /// });
+    /// ```
+    /// ---
+    /// ## Test
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rxpress::Request;
+    ///
+    /// let req = Request::new("GET /search?q=rust HTTP/1.1", HashMap::new(), "".into());
+    /// assert_eq!(req.query_expect("q").unwrap(), "rust");
+    /// assert!(req.query_expect("page").is_err());
+    /// ```
+    pub fn query_expect(&self, key: &str) -> Result<&str, String> {
+        self.query.get(key).map(|val| val.as_str()).ok_or(format!(
+            "[rxpress error]: Required query parameter `{}` is missing. \
+            Please include it in your request, e.g., `/route?{}=value`.",
+            key, key
+        ))
     }
 
     /*---- Private Functions ----*/
@@ -129,33 +453,117 @@ impl Request {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
-    #[test]
-    fn test_parse_request_line_and_query() {
-        let mut headers = HashMap::new();
-        headers.insert("Host".into(), "localhost".into());
-
-        let req = Request::new(
-            "GET /hello?developer=alfaarghya HTTP/1.1",
-            headers,
-            "".into(),
-        );
-
-        assert_eq!(req.method, "GET");
-        assert_eq!(req.path, "/hello");
-        assert_eq!(req.version, "HTTP/1.1");
-        assert_eq!(req.query("developer"), Some(&"alfaarghya".to_string()));
+    fn make_req_line(line: &str) -> Request {
+        Request::new(line, HashMap::new(), "".into())
     }
 
+    // TEST - header test
     #[test]
-    fn test_headers_case_insensitive() {
+    fn test_header_case_insensitive() {
         let mut headers = HashMap::new();
         headers.insert("Content-Type".into(), "application/json".into());
-
         let req = Request::new("GET / HTTP/1.1", headers, "".into());
+
         assert_eq!(
             req.header("content-type"),
             Some(&"application/json".to_string())
         );
+    }
+
+    #[test]
+    fn test_header_or() {
+        let mut headers = HashMap::new();
+        headers.insert("Content-Type".into(), "application/json".into());
+
+        let req = Request::new("GET / HTTP/1.1", headers, "".into());
+
+        assert_eq!(
+            req.header_or("Content-Type", "text/plain"),
+            "application/json"
+        );
+        assert_eq!(req.header_or("Non-Existent", "default"), "default");
+    }
+
+    #[test]
+    fn test_header_expect() {
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".into(), "Bearer abc123".into());
+
+        let req = Request::new("GET / HTTP/1.1", headers, "".into());
+
+        // Existing header
+        assert_eq!(req.header_expect("Authorization").unwrap(), "Bearer abc123");
+
+        // Missing header
+        let err = req.header_expect("X-Token").unwrap_err();
+        assert!(err.contains("Required header `X-Token` is missing"));
+    }
+
+    //TEST - params test
+    #[test]
+    fn test_param_insertion_and_lookup() {
+        let mut req = make_req_line("GET /users/1 HTTP/1.1");
+        req.params.insert("id".into(), "1".into());
+        assert_eq!(req.param("id"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn test_param_or() {
+        let mut req = Request::new("GET /users/ HTTP/1.1", HashMap::new(), "".into());
+        req.params.insert("id".into(), "42".into());
+
+        assert_eq!(req.param_or("id", "0"), "42");
+        assert_eq!(req.param_or("username", "guest"), "guest");
+    }
+
+    #[test]
+    fn test_param_expect() {
+        let mut req = Request::new("GET /users/42 HTTP/1.1", HashMap::new(), "".into());
+        req.params.insert("id".into(), "42".into());
+
+        // Existing param
+        assert_eq!(req.param_expect("id").unwrap(), "42");
+
+        // Missing param
+        let err = req.param_expect("username").unwrap_err();
+        assert!(err.contains("Required route parameter `username` is missing"));
+    }
+
+    //TEST - query test
+    #[test]
+    fn test_query_lookup() {
+        let req = make_req_line("GET /search?q=rust HTTP/1.1");
+        assert_eq!(req.query("q"), Some(&"rust".to_string()));
+    }
+
+    #[test]
+    fn test_query_or() {
+        let req = Request::new("GET /search?q=rust HTTP/1.1", HashMap::new(), "".into());
+
+        assert_eq!(req.query_or("q", "none"), "rust");
+        assert_eq!(req.query_or("page", "1"), "1");
+    }
+
+    #[test]
+    fn test_query_expect() {
+        let req = Request::new("GET /search?q=rust HTTP/1.1", HashMap::new(), "".into());
+
+        // Existing query
+        assert_eq!(req.query_expect("q").unwrap(), "rust");
+
+        // Missing query
+        let err = req.query_expect("page").unwrap_err();
+        assert!(err.contains("Required query parameter `page` is missing"));
+    }
+
+    //TEST - query parser(Private Method)
+    #[test]
+    fn test_parse_query_function() {
+        let parsed = Request::parse_query("a=1&b=2&empty");
+        assert_eq!(parsed.get("a"), Some(&"1".to_string()));
+        assert_eq!(parsed.get("b"), Some(&"2".to_string()));
+        assert_eq!(parsed.get("empty"), Some(&"".to_string()));
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,7 +6,7 @@ use std::net::TcpStream;
 ///
 /// Used by route handlers to set status codes, headers, and send body content.
 pub struct Response<'a> {
-    pub stream: &'a mut TcpStream,
+    stream: &'a mut TcpStream,
     pub headers: HashMap<String, String>,
     pub status: u16,
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,18 +1,42 @@
+//! # Response Module
+//!
+//! The [`Response`] struct is used to construct and send HTTP responses back to clients.
+//! It supports setting headers, status codes, sending plain text or JSON, and ensures a response
+//! is sent only once per request.
+//!
+//! ## Example
+//! ```no_run
+//! use std::net::TcpStream;
+//! use rxpress::Response;
+//!
+//! fn handler(stream: &mut TcpStream) {
+//!     let mut res = Response::new(stream);
+//!     res.set_header("X-Custom", "rxpress")
+//!        .status(201)
+//!        .json(r#"{"message":"Created"}"#);
+//! }
+//! ```
+
 use std::collections::HashMap;
 use std::io::Write;
 use std::net::TcpStream;
+
+use crate::status::{HttpStatus, StatusArg};
 
 /// Represents an HTTP response.
 ///
 /// Used by route handlers to set status codes, headers, and send body content.
 pub struct Response<'a> {
     stream: &'a mut TcpStream,
-    pub headers: HashMap<String, String>,
-    pub status: u16,
+    headers: HashMap<String, String>,
+    status: HttpStatus,
+    status_code: u16,
+    status_reason: String,
+    sent: bool,
 }
 
 impl<'a> Response<'a> {
-    /// Creates a new [`Response`] object with default status `200 OK`.
+    /// Creates a new Response with default `200 OK`.
     pub fn new(stream: &'a mut TcpStream) -> Response<'a> {
         let mut headers = HashMap::new();
         headers.insert("HTTP-Server-Powered-By".to_string(), "rxpress".to_string());
@@ -20,21 +44,67 @@ impl<'a> Response<'a> {
         Response {
             stream,
             headers,
-            status: 200,
+            status: HttpStatus::OK,
+            status_code: 200,
+            status_reason: "OK".to_string(),
+            sent: false,
         }
     }
 
-    /// Sets the HTTP status code.
+    /// Sets the HTTP status.
     ///
-    /// # Example
-    /// ```
-    /// # use rxpress::{Request, Response};
-    /// # fn handler(_req: &Request, res: &mut Response) {
-    /// res.status(404).send("Not found");
+    /// Supports `HttpStatus` enum, numeric codes, or custom code + reason.
+    ///
+    /// # Example (Standard Enum)
+    /// ```no_run
+    /// # use rxpress::{Response, HttpStatus};
+    /// # fn handler(res: &mut Response) {
+    /// res.status(HttpStatus::Forbidden).send("Forbidden!");
     /// # }
     /// ```
-    pub fn status(&mut self, code: u16) -> &mut Self {
-        self.status = code;
+    ///
+    /// # Example (Custom Code)
+    /// ```no_run
+    /// # use rxpress::Response;
+    /// # fn handler(res: &mut Response) {
+    /// res.status(511).json(r#"{"error":"Network Auth Required"}"#);
+    /// # }
+    /// ```
+    ///
+    /// # Example (Custom Code + Reason)
+    /// ```no_run
+    /// # use rxpress::Response;
+    /// # fn handler(res: &mut Response) {
+    /// res.status((599, "Network Timeout")).send("Timeout!");
+    /// # }
+    /// ```
+    ///
+    /// # Example (Multiple Calls)
+    /// ```no_run
+    /// # use rxpress::{Response, HttpStatus};
+    /// # fn handler(res: &mut Response) {
+    /// // Only the first send() is executed
+    /// res.status(HttpStatus::OK).send("First response");
+    /// res.json(r#"{"ignored": true}"#); // Will print warning and be ignored
+    /// # }
+    /// ```
+    pub fn status<'b, T: Into<StatusArg<'b>>>(&mut self, arg: T) -> &mut Self {
+        match arg.into() {
+            StatusArg::Enum(e) => {
+                self.status = e;
+                self.status_code = e.code();
+                self.status_reason = HttpStatus::reason(self.status_code).to_string();
+            }
+            StatusArg::Code(code) => {
+                self.status_code = code;
+                self.status_reason = HttpStatus::reason(code).to_string();
+            }
+            StatusArg::CodeReason(code, reason) => {
+                self.status_code = code;
+                self.status_reason = reason.to_string();
+            }
+        }
+
         self
     }
 
@@ -42,10 +112,9 @@ impl<'a> Response<'a> {
     ///
     /// # Example
     /// ```
-    /// # use rxpress::{Request, Response};
-    /// # fn handler(_req: &Request, res: &mut Response) {
-    /// res.set_header("X-Custom", "1234");
-    /// res.send("ok");
+    /// # use rxpress::{Response};
+    /// # fn handler(res: &mut Response) {
+    /// res.set_header("X-Custom", "1234").send("ok");
     /// # }
     /// ```
     pub fn set_header(&mut self, key: &str, value: &str) -> &mut Self {
@@ -57,12 +126,20 @@ impl<'a> Response<'a> {
     ///
     /// # Example
     /// ```
-    /// # use rxpress::{Request, Response};
-    /// # fn handler(_req: &Request, res: &mut Response) {
+    /// # use rxpress::{Response};
+    /// # fn handler(res: &mut Response) {
     /// res.send("Hello, plain text!");
+    /// res.send("Ignored"); // will print warning
     /// # }
     /// ```
     pub fn send(&mut self, msg: &str) {
+        if self.sent {
+            eprintln!(
+                "[rxpress warning!]: response already sent, ignoring subsequent send() call."
+            );
+            return;
+        }
+        self.sent = true; // mark as sent
         self.set_header("Content-Type", "text/plain");
         self.write_response(msg.as_bytes());
     }
@@ -71,17 +148,26 @@ impl<'a> Response<'a> {
     ///
     /// # Example
     /// ```
-    /// # use rxpress::{Request, Response};
-    /// # fn handler(_req: &Request, res: &mut Response) {
+    /// # use rxpress::{Response};
+    /// # fn handler(res: &mut Response) {
     /// res.json(r#"{"message":"ok"}"#);
+    /// res.json(r#"{"ignored": true}"#); // will print warning
     /// # }
     /// ```
     pub fn json(&mut self, msg: &str) {
+        if self.sent {
+            eprintln!(
+                "[rxpress warning!]: response already sent, ignoring subsequent json() call."
+            );
+            return;
+        }
+        self.sent = true; // mark as sent
         self.set_header("Content-Type", "application/json");
         self.write_response(msg.as_bytes());
     }
 
     /*---- Private Functions ----*/
+    /// Send header & response message
     fn write_response(&mut self, msg: &[u8]) {
         let headers = self
             .headers
@@ -92,8 +178,9 @@ impl<'a> Response<'a> {
 
         // println!("[write_response]: {headers:?}");
         let res = format!(
-            "HTTP/1.1 {} OK\r\n{}\r\nContent-Length: {}\r\n\r\n",
-            self.status,
+            "HTTP/1.1 {} {}\r\n{}\r\nContent-Length: {}\r\n\r\n",
+            self.status_code,
+            self.status_reason,
             headers,
             msg.len()
         );
@@ -101,5 +188,71 @@ impl<'a> Response<'a> {
         self.stream.write_all(res.as_bytes()).unwrap();
         self.stream.write_all(msg).unwrap();
         self.stream.flush().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{TcpListener, TcpStream};
+
+    // helper to get a connected TcpStream pair
+    fn tcp_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client = TcpStream::connect(addr).unwrap();
+        let server = listener.accept().unwrap().0;
+
+        (client, server)
+    }
+
+    // TEST - set custom header
+    #[test]
+    fn test_set_header() {
+        let (_c, mut s) = tcp_pair();
+        let mut res = Response::new(&mut s);
+        res.set_header("X-Test", "123");
+        assert_eq!(res.headers.get("X-Test"), Some(&"123".to_string()));
+    }
+
+    // TEST - sent status from HttpStatus enum
+    #[test]
+    fn test_status_with_enum() {
+        let (_c, mut s) = tcp_pair();
+        let mut res = Response::new(&mut s);
+        res.status(HttpStatus::Forbidden);
+        assert_eq!(res.status_code, 403);
+        assert_eq!(res.status_reason, "Forbidden");
+    }
+
+    // TEST - sent status code with custom reason
+    #[test]
+    fn test_status_with_custom_code_and_reason() {
+        let (_c, mut s) = tcp_pair();
+        let mut res = Response::new(&mut s);
+        res.status((499, "Custom Reason"));
+        assert_eq!(res.status_code, 499);
+        assert_eq!(res.status_reason, "Custom Reason");
+    }
+
+    // TEST - send test/plain response OR application/json response
+    #[test]
+    fn test_send_and_json_set_content_type() {
+        let (_c, mut s) = tcp_pair();
+        let mut res = Response::new(&mut s);
+        res.send("hello");
+        assert_eq!(
+            res.headers.get("Content-Type"),
+            Some(&"text/plain".to_string())
+        );
+
+        let (_c2, mut s2) = tcp_pair();
+        let mut res2 = Response::new(&mut s2);
+        res2.json(r#"{"msg":"ok"}"#);
+        assert_eq!(
+            res2.headers.get("Content-Type"),
+            Some(&"application/json".to_string())
+        );
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,3 +1,4 @@
+use crate::HttpStatus;
 use crate::request::Request;
 use crate::response::Response;
 use crate::route::Route;
@@ -28,6 +29,6 @@ impl Router {
             }
         }
 
-        res.status(404).send("404 Not Found");
+        res.status(HttpStatus::NotFound).send("404 Not Found");
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,24 @@
+//! # Server Module
+//!
+//! This module provides the core [`Server`] struct, which manages the HTTP server,
+//! registers routes, and dispatches requests to handlers.  
+//! It is the main entrypoint when building apps with `rxpress`.
+//!
+//! ## Example
+//! ```no_run
+//! use rxpress::Server;
+//!
+//! fn main() {
+//!     let mut app = Server::new("8080");
+//!
+//!     app.get("/", |_req, res| {
+//!         res.send("Hello, world!");
+//!     });
+//!
+//!     app.run(); // blocks forever
+//! }
+//! ```
+
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Lines, Read};
 use std::net::{TcpListener, TcpStream};
@@ -6,9 +27,23 @@ use crate::request::Request;
 use crate::response::Response;
 use crate::router::Router;
 
+/// Type alias for a request handler function.
+///
+/// Handlers receive the [`Request`] and a mutable reference to the [`Response`].
+///
+/// ```no_run
+/// use rxpress::{Request, Response};
+///
+/// fn handler(_req: &Request, res: &mut Response) {
+///     res.send("Hello!");
+/// }
+/// ```
 pub type Handler = fn(&Request, &mut Response);
 
 /// A simple HTTP server for handling requests.
+///
+/// The [`Server`] manages a [`Router`] internally, where routes are registered
+/// using convenience methods such as [`Server::get`] or [`Server::post`].
 ///
 /// # Example
 /// ```no_run

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,217 @@
+//! # Status Module
+//!
+//! Provides HTTP status codes and utilities for working with them.
+//!
+//! The [`HttpStatus`] enum represents standard HTTP status codes (1xx–5xx) with
+//! associated methods to get numeric codes and reason phrases.
+
+/// Standard HTTP status codes.
+///
+/// # Example
+/// ```
+/// use rxpress::HttpStatus;
+///
+/// // Get numeric code
+/// assert_eq!(HttpStatus::OK.code(), 200);
+///
+/// // Get reason phrase
+/// assert_eq!(HttpStatus::reason(404), "Not Found");
+/// ```
+
+/// Represents Standard HTTP status Codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HttpStatus {
+    // 1xx Informational
+    Continue = 100,
+    SwitchingProtocols = 101,
+    Processing = 102,
+    EarlyHints = 103,
+
+    // 2xx Success
+    OK = 200,
+    Created = 201,
+    Accepted = 202,
+    NonAuthoritativeInformation = 203,
+    NoContent = 204,
+    ResetContent = 205,
+    PartialContent = 206,
+    MultiStatus = 207,
+    AlreadyReported = 208,
+    ImUsed = 226,
+
+    // 3xx Redirection
+    MultipleChoices = 300,
+    MovedPermanently = 301,
+    Found = 302,
+    SeeOther = 303,
+    NotModified = 304,
+    UseProxy = 305,
+    TemporaryRedirect = 307,
+    PermanentRedirect = 308,
+
+    // 4xx Client Errors
+    BadRequest = 400,
+    Unauthorized = 401,
+    PaymentRequired = 402,
+    Forbidden = 403,
+    NotFound = 404,
+    MethodNotAllowed = 405,
+    NotAcceptable = 406,
+    ProxyAuthenticationRequired = 407,
+    RequestTimeout = 408,
+    Conflict = 409,
+    Gone = 410,
+    LengthRequired = 411,
+    PreconditionFailed = 412,
+    PayloadTooLarge = 413,
+    UriTooLong = 414,
+    UnsupportedMediaType = 415,
+    RangeNotSatisfiable = 416,
+    ExpectationFailed = 417,
+    ImATeapot = 418,
+    MisdirectedRequest = 421,
+    UnprocessableEntity = 422,
+    Locked = 423,
+    FailedDependency = 424,
+    TooEarly = 425,
+    UpgradeRequired = 426,
+    PreconditionRequired = 428,
+    TooManyRequests = 429,
+    RequestHeaderFieldsTooLarge = 431,
+    UnavailableForLegalReasons = 451,
+
+    // 5xx Server Errors
+    InternalServerError = 500,
+    NotImplemented = 501,
+    BadGateway = 502,
+    ServiceUnavailable = 503,
+    GatewayTimeout = 504,
+    HttpVersionNotSupported = 505,
+    VariantAlsoNegotiates = 506,
+    InsufficientStorage = 507,
+    LoopDetected = 508,
+    NotExtended = 510,
+    NetworkAuthenticationRequired = 511,
+}
+
+impl HttpStatus {
+    //// Returns the reason phrase for a status code.
+    ///
+    /// # Example
+    /// ```
+    /// use rxpress::HttpStatus;
+    /// assert_eq!(HttpStatus::reason(200), "OK");
+    /// assert_eq!(HttpStatus::reason(404), "Not Found");
+    /// assert_eq!(HttpStatus::reason(418), "I'm a Teapot");
+    /// ```
+    pub fn reason(code: u16) -> &'static str {
+        match code {
+            // 1xx
+            100 => "Continue",
+            101 => "Switching Protocols",
+            102 => "Processing",
+            103 => "Early Hints",
+
+            // 2xx
+            200 => "OK",
+            201 => "Created",
+            202 => "Accepted",
+            203 => "Non-Authoritative Information",
+            204 => "No Content",
+            205 => "Reset Content",
+            206 => "Partial Content",
+            207 => "Multi-Status",
+            208 => "Already Reported",
+            226 => "IM Used",
+
+            // 3xx
+            300 => "Multiple Choices",
+            301 => "Moved Permanently",
+            302 => "Found",
+            303 => "See Other",
+            304 => "Not Modified",
+            305 => "Use Proxy",
+            307 => "Temporary Redirect",
+            308 => "Permanent Redirect",
+
+            // 4xx
+            400 => "Bad Request",
+            401 => "Unauthorized",
+            402 => "Payment Required",
+            403 => "Forbidden",
+            404 => "Not Found",
+            405 => "Method Not Allowed",
+            406 => "Not Acceptable",
+            407 => "Proxy Authentication Required",
+            408 => "Request Timeout",
+            409 => "Conflict",
+            410 => "Gone",
+            411 => "Length Required",
+            412 => "Precondition Failed",
+            413 => "Payload Too Large",
+            414 => "URI Too Long",
+            415 => "Unsupported Media Type",
+            416 => "Range Not Satisfiable",
+            417 => "Expectation Failed",
+            418 => "I'm a Teapot",
+            421 => "Misdirected Request",
+            422 => "Unprocessable Entity",
+            423 => "Locked",
+            424 => "Failed Dependency",
+            425 => "Too Early",
+            426 => "Upgrade Required",
+            428 => "Precondition Required",
+            429 => "Too Many Requests",
+            431 => "Request Header Fields Too Large",
+            451 => "Unavailable For Legal Reasons",
+
+            // 5xx
+            500 => "Internal Server Error",
+            501 => "Not Implemented",
+            502 => "Bad Gateway",
+            503 => "Service Unavailable",
+            504 => "Gateway Timeout",
+            505 => "HTTP Version Not Supported",
+            506 => "Variant Also Negotiates",
+            507 => "Insufficient Storage",
+            508 => "Loop Detected",
+            510 => "Not Extended",
+            511 => "Network Authentication Required",
+            _ => "",
+        }
+    }
+
+    /// Returns the numeric code for an enum variant.
+    ///
+    /// # Example
+    /// ```
+    /// use rxpress::HttpStatus;
+    /// assert_eq!(HttpStatus::OK.code(), 200);
+    /// assert_eq!(HttpStatus::NotFound.code(), 404);
+    /// ```
+    pub fn code(&self) -> u16 {
+        *self as u16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TEST - http status codes
+    #[test]
+    fn test_http_status_codes() {
+        assert_eq!(HttpStatus::OK.code(), 200);
+        assert_eq!(HttpStatus::NotFound.code(), 404);
+        assert_eq!(HttpStatus::InternalServerError.code(), 500);
+    }
+
+    // TEST - http status code reasons
+    #[test]
+    fn test_http_status_reason_lookup() {
+        assert_eq!(HttpStatus::reason(200), "OK");
+        assert_eq!(HttpStatus::reason(404), "Not Found");
+        assert_eq!(HttpStatus::reason(418), "I'm a Teapot");
+        assert_ne!(HttpStatus::reason(418), "I'm a teapot");
+    }
+}


### PR DESCRIPTION
### HttpStatus
 This module contains pre-defined status codes & reasons that can be used in `res.status()`

### Response update
+ now `res.status()` can take multiple arguments. Such as, `HttpStatus` enum OR only `numeric code` OR `numeric code + reason`
+ Now we can send HTML responses
+ warning on using multiple json()/send()/html() call with in one handler
